### PR TITLE
Pass most HTTP headers to and from origin

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ AWS.CredentialProviderChain.defaultProviders = [
   () => { return new AWS.EC2MetadataCredentials(); }
 ];
 
-var execute = function(endpoint, region, path, method, body) {
+var execute = function(endpoint, region, path, headers, method, body) {
   return new Promise((resolve, reject) => {
     var req = new AWS.HttpRequest(endpoint);
 
@@ -27,25 +27,27 @@ var execute = function(endpoint, region, path, method, body) {
     req.method = method || 'GET';
     req.path = path;
     req.region = region;
-
-    if(body) {
-      if(typeof body === "object") {
-        req.body = JSON.stringify(body);
-      } else {
-        req.body = body;
-      }
-    }
-
-    // Sense likes send GET request with body, which aws-sdk doesn't really allow. Translate to POST instead.
-    if(req.body && req.method == 'GET') {
-      req.method = 'POST';
-    }
+    req.body = body;
 
     req.headers['presigned-expires'] = false;
     req.headers.Host = endpoint.host;
 
     var signer = new AWS.Signers.V4(req, 'es');
     signer.addAuthorization(creds, new Date());
+
+    // Now we have signed the "headers", we add extra headers passing
+    // from the browser.  We must strip any connection control, transport encoding
+    // incorrect Origin headers, and make sure we don't change the Host header from
+    // the one used for signing
+    var entries = Object.entries(headers)
+    for (var i=0, len=entries.length; i<len; i++) {
+            if (entries[i][0] != "host" && 
+                entries[i][0] != "accept-encoding" &&
+                entries[i][0] != "connection" &&
+                entries[i][0] != "origin") {
+                req.headers[entries[i][0]] = entries[i][1]
+            }
+    }
 
     var send = new AWS.NodeHttpClient();
     send.handleRequest(req, null, (httpResp) => {
@@ -56,6 +58,7 @@ var execute = function(endpoint, region, path, method, body) {
       httpResp.on('end', (chunk) => {
         resolve({
           statusCode: httpResp.statusCode,
+          headers: httpResp.headers,
           body: body
         });
       });
@@ -91,10 +94,21 @@ var requestHandler = function(request, response) {
     var buf = Buffer.concat(body).toString();
 
     co(function*(){
-        return yield execute(context.endpoint, context.region, request.url, request.method, buf);
+        return yield execute(context.endpoint, context.region, request.url, request.headers, request.method, buf);
       })
       .then(resp => {
-        response.writeHead(resp.statusCode, { 'Content-Type': 'application/json' });
+        // We need to pass through the response headers from the origin
+        // back to the UA, but strip any connection control and content encoding
+        // headers
+        headers = {}
+        entries = Object.entries(resp.headers)
+        for (var i=0,  nent = entries.length; i<nent; i++) {
+                k = entries[i][0]; v=entries[i][1]
+                if (k != undefined && k != "connection" && k != "content-encoding") {
+                        headers[k] = v
+                }
+        }
+        response.writeHead(resp.statusCode, headers);
         response.end(resp.body);
       })
       .catch(err => {


### PR DESCRIPTION
At the moment no HTTP headers are explicitly passed through from the user-agent to the ElasticSearch server.

This means that plugins like kibana, which use different content types, do not work.

This is a quick (and not exactly pretty) patch to pass through most HTTP headers.  I'm dropping:

 * Connection control headers (as passing these through is nonsensical with a proxy)
 * Accept-Encoding and Content-Encoding headers, as either the HTTP server or client library is not being transparent with the transport encoding, so I'm just leaving it up to them to deal with
 * Origin headers, as this is breaking CORS when it is set to localhost:9090  (this is not the most elegant solution, but it works)

I also removed the special case translating GETs into POSTs. I suspect that passing headers through will likely make that work-around unneeded.  I haven't tested it, but the AWS API shim does seem to pass through the HTTP method cleanly these days